### PR TITLE
use couch_util_clock:rfc1123/0 for the date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.swp
 *.beam
 *.dump
+.rebar

--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -666,7 +666,7 @@ to_universal(LocalTime) ->
 
 server_headers() ->
     [{"Server", "MochiWeb/1.0 (" ++ ?QUIP ++ ")"},
-     {"Date", couch_util:rfc1123_date()}].
+     {"Date", couch_util_clock:rfc1123()}].
 
 make_code(X) when is_integer(X) ->
     [integer_to_list(X), [" " | httpd_util:reason_phrase(X)]];


### PR DESCRIPTION
i was able to measure a 2% speed improvement on my laptop.

PRs:
apache/couchdb-couch#70
https://github.com/apache/couchdb-mochiweb/pull/1

This closes COUCHDB-2734
